### PR TITLE
Fix for pound sign causing encode error in docker, python 3.4.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-with open('README.rst') as file:
+with open('README.rst', encoding='UTF-8') as file:
     long_description = file.read()
 
 setup(


### PR DESCRIPTION
Pound sign in `README.rst` causes installation to fail.

Project is run on ubuntu 14.04 in Docker container.
Python version: 3.4.3
```    
Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/var/www/gocardless-pro-python/setup.py", line 4, in <module>
        long_description = file.read()
      File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 1158: ordinal not in range(128)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/var/www/gocardless-pro-python/setup.py", line 4, in <module>

    long_description = file.read()

  File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode

    return codecs.ascii_decode(input, self.errors)[0]

UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 1158: ordinal not in range(128)

----------------------------------------
Cleaning up...
Command python setup.py egg_info failed with error code 1 in /var/www/gocardless-pro-python
Storing debug log for failure in /root/.pip/pip.log
```