### PR TITLE
Update supported Python versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ A Python client for interacting with the GoCardless Pro API.
 
 |circle-badge| |pypi-badge|
 
-Tested against Python 2.7, 3.5, 3.6, 3.7, 3.8, 3.9 and 3.10.
+Tested against Python 3.7, 3.8, 3.9, 3.10 and 3.11.
 
 - `"Getting Started" guide <https://developer.gocardless.com/getting-started/api/introduction/?lang=python>`_ with copy and paste Python code samples
 - `API reference`_

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ A Python client for interacting with the GoCardless Pro API.
 
 |circle-badge| |pypi-badge|
 
-Tested against Python 2.7, 3.3, 3.4, 3.5, 3.6 and 3.7.
+Tested against Python 2.7, 3.5, 3.6, 3.7, 3.8, 3.9 and 3.10.
 
 - `"Getting Started" guide <https://developer.gocardless.com/getting-started/api/introduction/?lang=python>`_ with copy and paste Python code samples
 - `API reference`_

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 responses>=0.10.16;python_version>"3.4"
 responses<0.10.16;python_version<="3.4"
 nose>=1.3.6
+pytest

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py35,py36,py37,py38,py39,py310
+envlist = py37,py38,py39,py310,py311
 toxworkdir=../tox
 
 [testenv]
 commands = pytest
-deps = -rrequirements-dev.txt
+deps = -r requirements-dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py33,py34,py35,py36,py37
+envlist = py27,py35,py36,py37,py38,py39,py310
 toxworkdir=../tox
 
 [testenv]
-commands = nosetests
+commands = pytest
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
The gocardless-pro Python module isn't tested for recent versions of Python (3.8, 3.9, 3.10, 3.11)

* 'Nose' no longer runs under py 3.10, therefore
* Have added pytest as it will run the exiting 'nose' based tests without changes
* Removed py 2.7, 3.3, 3.4, 3.5 and 3.6 support

Note: I was unable to use docker to run the tests, so used tox on it's own instead.  All tests passed.