### PR TITLE
Added long_description_content_type as text/markdown to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     author_email = 'engineering@gocardless.com',
     description = 'A client library for the GoCardless Pro API.',
     long_description = long_description,
+    long_description_content_type='text/markdown',
     license = 'MIT',
     keywords = 'gocardless directdebit payments sepa bacs',
     url = 'https://github.com/gocardless/gocardless-pro-python',


### PR DESCRIPTION
Added long_description_content_type as text/markdown to setup.py

Because of a change to pypi/warehouse which blocks uploads that have an invalid long_description that it won't be able to render https://github.com/pypi/warehouse/issues/5890. In order to fix this, we set long_description_content_type='text/markdown'.