### PR TITLE
Bump python version to 3.9 in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.9]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
As of Dec 15th 2022, [actions/setup-python](https://github.com/actions/setup-python) no longer supports Python 3.6 (https://github.com/actions/setup-python/issues/561).

Hence a number of our recent releases for the python library were not being published https://github.com/gocardless/gocardless-pro-python/actions 

The [suggestion](https://github.com/actions/setup-python/issues/561#issuecomment-1340657956) is to use python version 3.9 for ubuntu-latest (Ubuntu 22.04).