### PR TITLE
Fix: #63 malformed response when deleting a customer

### DIFF
--- a/gocardless_pro/api_client.py
+++ b/gocardless_pro/api_client.py
@@ -113,12 +113,18 @@ class ApiClient(object):
         return response
 
     def _handle_errors(self, response):
+
+        # HTTP 204 No Content - is a valid response with no payload
+        if response.status_code == 204:
+            return
+
         try:
             response_body = response.json()
         except ValueError:
             msg = 'Malformed response received from server'
             raise errors.MalformedResponseError(msg, response.text)
 
+        # Perform further inspection only for Client or Server error responses
         if response.status_code < 400:
             return
 

--- a/tests/api_client_test.py
+++ b/tests/api_client_test.py
@@ -54,10 +54,42 @@ def test_put_includes_json_body():
     assert_equals(responses.calls[0].request.body, '{"name": "Billy Jean"}')
 
 @responses.activate
-def test_delete_includes_json_body():
-    responses.add(responses.DELETE, 'http://example.com/test', body='{}')
-    client.delete('/test', body={'name': 'Billy Jean'})
-    assert_equals(responses.calls[0].request.body, '{"name": "Billy Jean"}')
+def test_delete_customer_successful():
+    responses.add(
+        responses.DELETE,
+        'http://example.com/customers/foobar',
+        status=204)
+
+    # No parameters or body are specified in the documentation
+    client.delete('/customers/foobar', body={})
+
+    # No assertions - request is expected to raise no exceptions
+
+
+@responses.activate
+def test_delete_customer_already_removed():
+
+    fixture = helpers.load_fixture('customer_gone')
+
+    responses.add(
+        responses.DELETE,
+        'http://example.com/customers/foobar',
+        status=fixture['error']['code'],
+        json=fixture)
+
+    # InvalidApiUsageError raise is expected
+    with assert_raises(errors.InvalidApiUsageError) as assertion:
+        # No parameters or body are specified in the documentation
+        client.delete('/customers/foobar', body={})
+
+    assert_equals(
+        assertion.exception.documentation_url,
+        fixture['error']['documentation_url'])
+
+    assert_equals(
+        assertion.exception.errors,
+        fixture['error']['errors'])
+
 
 @responses.activate
 def test_handles_validation_failed_error():

--- a/tests/fixtures/customer_gone.json
+++ b/tests/fixtures/customer_gone.json
@@ -1,0 +1,15 @@
+{
+  "error": {
+    "documentation_url": "https://developer.gocardless.com/api-reference#customer_data_removed",
+    "message": "This customer data has been removed",
+    "type": "invalid_api_usage",
+    "errors": [
+      {
+        "reason": "customer_removed",
+        "message": "This customer data has been removed"
+      }
+    ],
+    "code": 410,
+    "request_id": "deadbeef-0000-4000-0000-444400004444"
+  }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,5 @@ envlist = py38,py39,py310,py311
 toxworkdir=../tox
 
 [testenv]
-commands = pytest
+commands = pytest {posargs}
 deps = -r requirements-dev.txt


### PR DESCRIPTION
According to documentation (https://developer.gocardless.com/api-reference#customers-remove-a-customer) `HTTP 204 No Content` - is a valid answer, that contains no payload. 

`api_client.py::_handle_errors()` expects a jsonable body in response in any case. That goes wrong in case of `HTTP DELETE`. 

These changes introduce an exception for `HTTP 204` specifically.

Added two tests for both possible answers to deletion request: `HTTP 204 No Content` and `HTTP 410 Gone`. 

`tox.ini` updated in order to rapidly validate a single test - arguments are passed to `pytest`.