### PR TITLE
Remove transitive dependency 'six' from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name = 'gocardless_pro',
     version = '3.2.0',
     packages = find_packages(exclude=['tests']),
-    install_requires = ['requests>=2.6', 'six'],
+    install_requires = ['requests>=2.6'],
     author = 'GoCardless',
     author_email = 'engineering@gocardless.com',
     description = 'A client library for the GoCardless Pro API.',


### PR DESCRIPTION
As part of our ongoing research on Python dependency management we noticed a potential improvement in your project’s dependency management.

Specifically, the transitive dependency `six` is specified as an install requirement in the `setup.py` file, even though it is not used directly and does not need to be listed explicitly.

This PR removes it from `setup.py` to let pip manage it automatically, which helps keeping the dependency list clean.

Hope this is helpful!