### PR TITLE
Fix check_version step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Check if version tag exists
         id: check
         run: |
-          VERSION=$(python -c "import re; print(re.search(r\"version\s*=\s*['\"']([^'\"']+)['\"']\", open('setup.py').read()).group(1))")
+          VERSION=$(python -c "import re; print(re.search(r\"version\s*=\s*'([^']+)'\", open('setup.py').read()).group(1))")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
             echo "Tag v${VERSION} already exists, skipping publish"


### PR DESCRIPTION
The `r\"...\"` raw string breaks because in Python raw strings `\"` doesn't escape the quote — it literally terminates the string.

I tried the code locally and was able to reproduce the error. This version works locally and gets the right result.

This failed with:

```py
Run VERSION=$(python -c "import re; print(re.search(r\"version\s*=\s*['\"']([^'\"']+)['\"']\", open('setup.py').read()).group(1))")
  File "<string>", line 1
    import re; print(re.search(r"version\s*=\s*['"']([^'"']+)['"']", open('setup.py').read()).group(1))
                                                                                   ^
SyntaxError: unterminated string literal (detected at line 1) Error: Process completed with exit code 1.
```